### PR TITLE
Move flex-id to extra settings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "symfony/dotenv": "3.3.x-dev"
     },
     "config": {
-        "flex-id": "",
         "platform": {
             "php": "7.0"
         },
@@ -48,5 +47,8 @@
         "symfony/framework-bundle": "<3.3",
         "symfony/twig-bundle": "<3.3",
         "symfony/debug": "<3.3"
+    },
+    "extra": {
+        "flex-id": ""
     }
 }


### PR DESCRIPTION
As said by @stof in [this comment](https://github.com/symfony/skeleton/commit/beb77b84667a3338cf3156a10e9511cf040fdda1#commitcomment-21397542), even if `config` part is not validated by `composer validate`, custom settings should still be under `extra` to avoid `composer config` to fail update/modify/remove this value