### PR TITLE
Remove useless conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
     },
     "conflict": {
         "symfony/symfony": "<3.3",
-        "symfony/framework-bundle": "<3.3",
         "symfony/twig-bundle": "<3.3",
         "symfony/debug": "<3.3"
     },


### PR DESCRIPTION
Not much use to depend on `symfony/framework-bundle:3.3.x-dev` and then declare a conflict with `<3.3`.