### PR TITLE
Add Var-Dumper to require-dev: lets dump()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "symfony/yaml": "^3.3"
     },
     "require-dev": {
-        "symfony/dotenv": "^3.3"
+        "symfony/dotenv": "^3.3",
+        "symfony/var-dumper": "^3.3"
     },
     "config": {
         "platform": {


### PR DESCRIPTION
So that dump() is always available and part of the Flex experience.