### PR TITLE
Adding the extension XML for required by XmlUtils and not installed by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^7.1",
+        "ext-xml": "*",
         "symfony/flex": "^1.0",
         "symfony/framework-bundle": "^3.3",
         "symfony/yaml": "^3.3"


### PR DESCRIPTION
Adding the XML extension which is not installed by default. What throws an exception on the class : ``` Symfony\Component\Config\Util\XmlUtils ```

![capture du 2017-05-05 17-49-37](https://cloud.githubusercontent.com/assets/1810304/25753507/1748d436-31bc-11e7-961f-dbf2128019a6.png)
