### PR TITLE
Change platform to 7.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Project description",
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1.3",
         "symfony/flex": "^1.0",
         "symfony/framework-bundle": "^3.3",
         "symfony/yaml": "^3.3"
@@ -15,7 +15,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.1"
+            "php": "7.1.3"
         },
         "preferred-install": {
             "*": "dist"


### PR DESCRIPTION
To match the requirement of Symfony 4 and prevent errors like this:

```
  Problem 1
    - Installation request for symfony/console ^4.0@dev -> satisfiable by symfony/console[4.0.x-dev].
    - symfony/console 4.0.x-dev requires php ^7.1.3 -> your PHP version (7.1.5) overridden by "config.platform.php" version (7.1) does not satisfy that requirement.
 ```