### PR TITLE
Conflict with symfony/symfony (any version) to prevent project self-destruct

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         ]
     },
     "conflict": {
-        "symfony/symfony": "<3.3",
+        "symfony/symfony": "*",
         "symfony/twig-bundle": "<3.3",
         "symfony/debug": "<3.3"
     },


### PR DESCRIPTION
Lesson learnt the hard way.

Installing a bundle that required `symfony/symfony` resulted in catastrophic auto-unconfiguring. Even `etc/packages/app.yaml` and `etc/container.yaml` are gone (as they are from the `symfony/framework-bundle` recipe).