### PR TITLE
Change tests namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "App\\Tests\\": "tests/"
+            "Tests\\App\\": "tests/"
         }
     },
     "scripts": {


### PR DESCRIPTION
I would prefer to use `Tests\App\` rather than `App\Tests\`. Like in the Standard edition.  
What do you think?