### PR TITLE
PHP Version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Project description",
     "minimum-stability": "beta",
     "require": {
-        "php": "^7.0.8",
+        "php": "^7.1.3",
         "symfony/flex": "^1.0",
         "symfony/console": "^4.0",
         "symfony/framework-bundle": "^4.0",


### PR DESCRIPTION
Hi fabien, 

well i guess this makes sense as symfony4 requires php7.1.3

cheers,