### PR TITLE
Alphabetise require declarations.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "description": "Project description",
     "require": {
         "php": "^7.0.8",
-        "symfony/flex": "^1.0",
         "symfony/console": "^3.3",
+        "symfony/flex": "^1.0",
         "symfony/framework-bundle": "^3.3",
         "symfony/yaml": "^3.3"
     },


### PR DESCRIPTION
We're using sort-packages so lets provide a sorted list to start with.

Without this, the first time somebody runs `composer install` these two lines get switched, so lets not add that diff noise.