### PR TITLE
Fix minimum required PHP version for Symfony4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Project description",
     "minimum-stability": "beta",
     "require": {
-        "php": "^7.0.8",
+        "php": "^7.1.3",
         "symfony/console": "^4.0",
         "symfony/flex": "^1.0",
         "symfony/framework-bundle": "^4.0",


### PR DESCRIPTION
Symfony4 requires minimum PHP version 7.1.3, but in the current composer.json it is 7.0.8