### PR TITLE
"replace" 7.0 & 5.6 polyfills

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "description": "Project description",
     "require": {
         "php": "^7.0.8",
+        "ext-iconv": "*",
         "symfony/console": "^3.3",
         "symfony/flex": "^1.0",
         "symfony/framework-bundle": "^3.3",
@@ -28,6 +29,11 @@
         "psr-4": {
             "App\\Tests\\": "tests/"
         }
+    },
+    "replace": {
+        "symfony/polyfill-apcu": "*",
+        "symfony/polyfill-php70": "*",
+        "symfony/polyfill-php56": "*"
     },
     "scripts": {
         "auto-scripts": [


### PR DESCRIPTION
This removes `paragonie/random_compat`, `symfony/polyfill-php70` and  `symfony/polyfill-apcu` from minimal install - they are not needed since PHP 7.0.
And removes  `symfony/polyfill-php56` for deps that would need it (eg symfony/security).

ext-iconv is already an implicit requirement for Symfony.
