### PR TITLE
"replace" polyfill-iconv, but not polyfill-apcu

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "replace": {
-        "symfony/polyfill-apcu": "*",
+        "symfony/polyfill-iconv": "*",
         "symfony/polyfill-php70": "*",
         "symfony/polyfill-php56": "*"
     },


### PR DESCRIPTION
No v4 Symony component require these. Let's simplify composer.json.