### PR TITLE
Use symfony/lts for 3.3 branch too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "symfony/console": "^3.3",
         "symfony/flex": "^1.0",
         "symfony/framework-bundle": "^3.3",
+        "symfony/lts": "^3",
         "symfony/yaml": "^3.3"
     },
     "require-dev": {


### PR DESCRIPTION
`composer create-project symfony/skeleton test "3.3.*"` as specified in example in http://symfony.com/doc/current/setup.html currently downloads `4.*` packages