### PR TITLE
Updated license and description in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "symfony/skeleton",
     "type": "project",
-    "license": "proprietary",
-    "description": "Project description",
+    "license": "MIT",
+    "description": "A minimal Symfony project recommended to create new applications.",
     "require": {
         "php": "^7.0.8",
         "ext-iconv": "*",


### PR DESCRIPTION
The "proprietary" license with unknown terms prevents it from being used by anyone.
Assuming that skeleton is replacing symfony/symfony-standard, shoudn't the license be the same (MIT) ?