### PR TITLE
[master-only] Replace symfony/lts by symfony/force-lowest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         "ext-iconv": "*",
         "symfony/console": "^4.1",
         "symfony/flex": "^1.0",
+        "symfony/force-lowest": "=4.1",
         "symfony/framework-bundle": "^4.1",
-        "symfony/lts": "^4@dev",
         "symfony/yaml": "^4.1"
     },
     "require-dev": {


### PR DESCRIPTION
Two issues fixed here, required to have a smooth feature freeze period:
- removing `symfony/lts` fixes https://github.com/symfony/skeleton/issues/58 by working around https://github.com/composer/composer/issues/6852
- adding constraints on lowest versions of `symfony/*` forces them to be installed at 4.1, while the default will usually install 4.0.* thanks to the prefer-stable policy.

This reasoning is for master only. It doesn't apply to lower branches.