### PR TITLE
Fix 4.1: force-lowest is only for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         "ext-iconv": "*",
         "symfony/console": "^4.1",
         "symfony/flex": "^1.0",
-        "symfony/force-lowest": "=4.1",
         "symfony/framework-bundle": "^4.1",
+        "symfony/lts": "^4@dev",
         "symfony/yaml": "^4.1"
     },
     "require-dev": {


### PR DESCRIPTION
Should be added to our releasing policies: when doing a new release, we should do this change before tagging. force-lowest is only for master, to force installing latest unreleased versions of Symfony components when minimum stability is set to dev on create-project.