### PR TITLE
Remove symfony/symfony from conflict section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,9 +48,6 @@
             "@auto-scripts"
         ]
     },
-    "conflict": {
-        "symfony/symfony": "*"
-    },
     "extra": {
         "symfony": {
             "allow-contrib": false


### PR DESCRIPTION
Instead, I propose https://github.com/symfony/recipes/pull/423
Reason described in https://github.com/symfony/symfony/pull/27616