### PR TITLE
Use extra.symfony.require to restrict versions of symfony/*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,13 @@
         "php": "^7.0.8",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "symfony/console": "^3.4",
-        "symfony/flex": "^1.0",
-        "symfony/framework-bundle": "^3.4",
-        "symfony/lts": "^3",
-        "symfony/yaml": "^3.4"
+        "symfony/console": "*",
+        "symfony/flex": "^1.1",
+        "symfony/framework-bundle": "*",
+        "symfony/yaml": "*"
     },
     "require-dev": {
-        "symfony/dotenv": "^3.4"
+        "symfony/dotenv": "*"
     },
     "config": {
         "preferred-install": {
@@ -53,7 +52,8 @@
     },
     "extra": {
         "symfony": {
-            "allow-contrib": false
+            "allow-contrib": false,
+            "require": "3.4.*"
         }
     }
 }


### PR DESCRIPTION
Proposed way to leverage https://github.com/symfony/flex/pull/409

Benefits:
- no `symfony/lts` / `symfony/force-lowest` anymore
- only one line to change to upgrade to next minor
- better control of exact minor used (right now, skeleton:4.0 pulls 4.1 components)
- (and a lot less merge conflicts for us when merging 3.4 up to master);