### PR TITLE
Add 4.2 branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,9 @@
         "symfony": {
             "allow-contrib": false,
             "require": "4.2.*"
+        },
+        "branch-alias": {
+            "dev-master": "4.2-dev"
         }
     }
 }


### PR DESCRIPTION
So we can use the following command (I believe 🤔)
```
composer create-project symfony/skeleton:4.2@dev messenger-workshop
```

instead of using `symfony/skeleton:dev-master`.