### PR TITLE
Move dotenv to "require"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,10 @@
         "ext-ctype": "*",
         "ext-iconv": "*",
         "symfony/console": "*",
+        "symfony/dotenv": "*",
         "symfony/flex": "^1.1",
         "symfony/framework-bundle": "*",
         "symfony/yaml": "*"
-    },
-    "require-dev": {
-        "symfony/dotenv": "*"
     },
     "config": {
         "preferred-install": {


### PR DESCRIPTION
This doesn't hurt anything and should ease using .env files without issues.