### PR TITLE
Add minimum-stability=dev & prefer-stable=true

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "MIT",
     "description": "A minimal Symfony project recommended to create bare bones applications",
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": ">=7.2.5",
         "ext-ctype": "*",


### PR DESCRIPTION
minimum-stability=dev is already there but we previously removed it before tagging a version.
For 5.2.99, I propose to keep it and to add prefer-stable=true.

This will ease using unstable versions when the constraints require them.
It will prevent using unstable versions when stable ones fit the constraints.