### PR TITLE
Add Runtime component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "symfony/console": "*",
         "symfony/dotenv": "*",
         "symfony/framework-bundle": "*",
+        "symfony/runtime": "*",
         "symfony/yaml": "*"
     },
     "require-dev": {


### PR DESCRIPTION
If https://github.com/symfony/recipes/pull/787 is merged and I run 

```
symfony new acme --version=next
```

Now I will have a front controller that require `dirname(__DIR__).'/vendor/autoload_runtime.php'`, but that file does not exist. 

If you are starting a new Symfony project, you will run it somehow => hence, you need the runtime component. 