### PR TITLE
Use stable stability for the 5.3 skeleton

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,6 @@
     "type": "project",
     "license": "MIT",
     "description": "A minimal Symfony project recommended to create bare bones applications",
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "require": {
         "php": ">=7.2.5",
         "ext-ctype": "*",


### PR DESCRIPTION
Using `minimum-stability: dev` with `prefer-stable: true` does not guarantee at all that you get a solver solution using only stable deps if it exists. That's because `prefer-stable: true` affects local decisions, not a global selection between solutions (because the solver won't look for multiple solutions anyway). See https://github.com/composer/composer/issues/9917 for an example.
For stable symfony versions, it is better to stick with the composer default of using `minimum-stability: stable`, to avoid surprises (I saw some people reporting on Slack during the stabilization phase that the orm-pack ended up instead doctrine/orm 3.0.x-dev for them in some cases, which is far from being ready, for instance).