### PR TITLE
Bump Flex to 1.17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=7.1.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "symfony/flex": "^1.3.1"
+        "symfony/flex": "^1.17"
     },
     "flex-require": {
         "symfony/console": "*",


### PR DESCRIPTION
Following https://symfony.com/blog/upgrade-flex-on-your-symfony-projects

The blog article tells the world not to use Flex versions older than 1.17. I think it would be wise to update the skeleton to reflect this request.