### PR TITLE
Add allow-plugins in the skeleton config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     "require-dev": {
     },
     "config": {
+        "allow-plugins": {
+            "symfony/flex": true
+        },
         "preferred-install": {
             "*": "dist"
         },


### PR DESCRIPTION
Refs https://github.com/composer/composer/pull/10314

For now, the default value in Composer is still to allow all plugins implicitly for BC. But the behavior will change in July 2022 to default to an empty list of allowed plugins.

This PR has 2 effects:
- it makes new project use the new Composer behavior directly instead of relying on the BC layer
- it marks `symfony/flex` as an allowed plugin, as our skeleton is meant to be used with Flex

The first point means that projects installing other composer plugins will need to mark them as allowed for them to run (but `composer update` running in an interactive shell will ask for that anyway)