### PR TITLE
Drop allowing for unused composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     },
     "config": {
         "allow-plugins": {
-            "composer/package-versions-deprecated": true,
             "symfony/flex": true,
             "symfony/runtime": true
         },


### PR DESCRIPTION
There is no installed `composer/package-versions-deprecated` after project initialization

```bash
$ symfony new test --no-git > /dev/null 2>&1 && cd test
$ composer why composer/package-versions-deprecated

In BaseDependencyCommand.php line 78:
                                                                                 
  Could not find package "composer/package-versions-deprecated" in your project  
                                                                                 

depends [-r|--recursive] [-t|--tree] [--] <package>
```