### PR TITLE
 Remove composer/package-versions-deprecated from allowed plugins 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     },
     "config": {
         "allow-plugins": {
-            "composer/package-versions-deprecated": true,
             "symfony/flex": true,
             "symfony/runtime": true
         },


### PR DESCRIPTION
Not needed since https://github.com/composer/composer/releases/tag/2.2.5

Let ppl on older composer versions see the regular prompt.

For branch 6.2 only.