### PR TITLE
Revert "Merge pull request #180 from lyrixx/composer-autoload-optimize"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
             "symfony/flex": true,
             "symfony/runtime": true
         },
-        "optimize-autoloader": true,
         "sort-packages": true
     },
     "autoload": {


### PR DESCRIPTION
This reverts commit ef88b9d12021bc884ec58530401cf910ded9b415, reversing changes made to 29d693dad4110dd06f790c23a1a8142a58ad15fd.

During the workshop at SymfonyCon, I figured out the slow part of using composer was "Generating optimized autoload files".

I'm proposing to remove this to improve the DX in dev.