### PR TITLE
Fix require part for 6.3 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "6.2.*"
+            "require": "6.3.*"
         }
     }
 }


### PR DESCRIPTION
Currently it still installs and require 6.2 on 6.3@dev skeleton.