### PR TITLE
Remove "polyfill-icon" from composer replace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
     },
     "replace": {
         "symfony/polyfill-ctype": "*",
-        "symfony/polyfill-iconv": "*",
         "symfony/polyfill-php72": "*",
         "symfony/polyfill-php73": "*",
         "symfony/polyfill-php74": "*",


### PR DESCRIPTION
AFAIK, symfony/polyfill-iconv isnt required by any package in symfony/*