### PR TITLE
Update PHP version requirement to 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "symfony/flex": "^2"


### PR DESCRIPTION
Since Symfony 8 requires at least PHP 8.4